### PR TITLE
feat: 在 docusaurus deploy 前进行 latest version 纯文本替换

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.7'
+          architecture: 'x64'
+      - run: python replace_latest_version_in_md.py
       - uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}

--- a/docs/android/base/Configuration.md
+++ b/docs/android/base/Configuration.md
@@ -185,7 +185,7 @@ APP 内嵌H5页面如果也需要进行数据采集，H5页面需要集成 Web J
 :::
 ```groovy
 ...
-implementation "com.growingio.android:hybrid:3.3.5"
+implementation "com.growingio.android:hybrid:<AndroidSDKVersion />"
 ```
 
 SDK初始化时需要注册 hybrid 模块：
@@ -212,7 +212,7 @@ GrowingTracker.get().bridgeWebView(webview)
 采集 SDK 版本 >=3.3.0
 
 > 在 OAID SDK 1.0.26及其后续版本，获得OAID值需要传入从 MSA 机构获得的证书；
-> 3.3.0 ~ 3.3.3版本无法传入客户自己获得的OAID值或OAID证书，若需要这些功能，请使用最新的版本 >=3.3.4。
+> 3.3.0 ~ 3.3.3版本无法传入客户自己获得的OAID值或OAID证书，若需要这些功能，请使用版本 >=3.3.4。
 
 **使用时注意模块版本需要与采集SDK版本保持一致**
 :::
@@ -220,7 +220,7 @@ GrowingTracker.get().bridgeWebView(webview)
 项目需要添加[国内移动安全联盟MSA](http://www.msa-alliance.cn/col.jsp?id=120)下的sdk包，和 OAID模块依赖(和 SDK 依赖同级)：
 ```groovy
 ...
-implementation "com.growingio.android:oaid:3.3.5"
+implementation "com.growingio.android:oaid:<AndroidSDKVersion />"
 ```
 SDK初始化时注册Oaid模块：
 
@@ -336,7 +336,7 @@ GrowingTracker.startWithConfiguration(this,
 项目需要添加加密模块依赖(和 SDK 依赖同级)
 ```groovy
 ...
-implementation "com.growingio.android:encoder:3.3.5"
+implementation "com.growingio.android:encoder:<AndroidSDKVersion />"
 ```
 
 SDK初始化时注册加密模块：
@@ -372,7 +372,7 @@ GrowingTracker.startWithConfiguration(this,
 项目需要添加Protobuf模块依赖(和 SDK 依赖同级)
 ```groovy
 ...
-implementation "com.growingio.android:protobuf:3.3.5"
+implementation "com.growingio.android:protobuf:<AndroidSDKVersion />"
 ```
 
 SDK初始化时注册Protobuf模块：

--- a/docs/android/base/index.md
+++ b/docs/android/base/index.md
@@ -37,7 +37,7 @@ buildscript {
     dependencies {
         
         //GrowingIO 无埋点 SDK plugin
-        classpath 'com.growingio.android:autotracker-gradle-plugin:3.3.5'
+        classpath 'com.growingio.android:autotracker-gradle-plugin:<AndroidSDKVersion />'
     }
 }
 ```
@@ -81,7 +81,7 @@ apply plugin: 'com.growingio.android.autotracker'
 dependencies {
     ...
     //GrowingIO 无埋点 SDK
-    implementation 'com.growingio.android:autotracker-cdp:3.3.5'
+    implementation 'com.growingio.android:autotracker-cdp:<AndroidSDKVersion />'
 }
 
 ```
@@ -202,7 +202,7 @@ class MyApplication : Application() {
 ### 查看集成效果
 运行应用，若 `Logcat` 中输出了  
 `!!! Thank you very much for using GrowingIO. We will do our best to provide you with the best service. !!!`  
-`!!! GrowingIO Tracker version: 3.3.4 !!!`  
+`!!! GrowingIO Tracker version: <AndroidSDKVersion /> !!!`  
 则说明SDK已经集成成功。
 
 若在初始化中打开了Debug `setDebugEnabled(true)` ，则可以在 `Logcat` 中看到每个事件的log日志输出。
@@ -230,7 +230,7 @@ repositories {
 dependencies {
 
     //GrowingIO 埋点 SDK
-    implementation 'com.growingio.android:tracker-cdp:3.3.5'
+    implementation 'com.growingio.android:tracker-cdp:<AndroidSDKVersion />'
 }
 ```
 
@@ -332,7 +332,7 @@ SDK中已经默认集成了混淆规则，R8 在编译项目时会自动应用�
 ### 查看集成效果
 运行应用，若 `Logcat` 中输出了  
 `!!! Thank you very much for using GrowingIO. We will do our best to provide you with the best service. !!!`  
-`!!! GrowingIO Tracker version: 3.3.4 !!!`  
+`!!! GrowingIO Tracker version: <AndroidSDKVersion /> !!!`  
 则说明SDK已经集成成功。
 
 若在初始化中打开了Debug `setDebugEnabled(true)` ，则可以在 `Logcat` 中看到每个事件的log日志输出。

--- a/docs/android/develop/coutom sdk.md
+++ b/docs/android/develop/coutom sdk.md
@@ -12,18 +12,18 @@ SDK 可以通过集成不同的模块实现功能的自定义，在 GrowingIO �
 
 | 名称     | 说明 | 输入数据 | 输出数据 | 依赖 |
 | :------- | :------:   | ---:|  ---:| :---|
-| 网络库-okhttp | 使用okhttp请求网络，sdk默认网络模块 | `EventUrl` | `EventResponse` | `com.growingio.android:okhttp3:3.3.5` |
-| 网络库-urlconnnection | 使用原生`urlconnnection`请求网络 | `EventUrl` | `EventResponse` | `com.growingio.android:urlconnection:3.3.5` |
-| 网络库-volley | 使用volley请求网络 | `EventUrl` | `EventResponse` | `com.growingio.android:volley:3.3.5` |
-| 数据加密-encoder | 使用 snappy 加密上报的事件数据,需要集成生效 | `EventEncoder` | `EventEncoder` | `com.growingio.android:encoder:3.3.5` |
-| 设备标识符-oaid | 提供采集 OAID 的能力,需要集成生效 | `OaidHelper` | `String` | `com.growingio.android:oaid:3.3.5` |
-| 数据异常上报工具-crash | sdk 异常崩溃上报纸 sentry，需要集成生效 | 无 | 无 | `com.growingio.android:crash:3.3.5` |
-| 无埋点圈选-circler | 基于无埋点的圈选插件，默认集成在无埋点SDK中 | `Circler` | `WebService` |`com.growingio.android:circler:3.3.5` |
-| 数据调试-debugger | 数据调试Mobile Debugger，默认集成在埋点SDK中 | `Debugger` | `WebService` | `com.growingio.android:debugger:3.3.5` |
-| 混合开发数据收集-hybrid | 混合开发模式，默认集成在埋点SDK中，需要手动注入（无埋点中自动注入） | 1. `HybridBridge` <br /> 2. `HybridDom` | 1. `Boolean` <br /> 2.`HybridJson` | `com.growingio.android:hybird:3.3.5` |
-| 数据库-database | event数据库为sqplite，默认集成在埋点SDK中 | `EventDatabase` | `EventDbResult` | `com.growingio.android:database:3.3.5` |
-| 数据传输格式-json | 使用json格式保存和上传事件数据，sdk 默认 | `EventFormatData` | `EventByteArray` | `com.growingio.android:json:3.3.5` |
-| 数据传输格式-protobuf | 使用protobuf格式保存和上传事件数据，需要集成生效 | `EventFormatData` | `EventByteArray` | `com.growingio.android:protobuf:3.3.5` |
+| 网络库-okhttp | 使用okhttp请求网络，sdk默认网络模块 | `EventUrl` | `EventResponse` | `com.growingio.android:okhttp3:<AndroidSDKVersion />` |
+| 网络库-urlconnnection | 使用原生`urlconnnection`请求网络 | `EventUrl` | `EventResponse` | `com.growingio.android:urlconnection:<AndroidSDKVersion />` |
+| 网络库-volley | 使用volley请求网络 | `EventUrl` | `EventResponse` | `com.growingio.android:volley:<AndroidSDKVersion />` |
+| 数据加密-encoder | 使用 snappy 加密上报的事件数据,需要集成生效 | `EventEncoder` | `EventEncoder` | `com.growingio.android:encoder:<AndroidSDKVersion />` |
+| 设备标识符-oaid | 提供采集 OAID 的能力,需要集成生效 | `OaidHelper` | `String` | `com.growingio.android:oaid:<AndroidSDKVersion />` |
+| 数据异常上报工具-crash | sdk 异常崩溃上报纸 sentry，需要集成生效 | 无 | 无 | `com.growingio.android:crash:<AndroidSDKVersion />` |
+| 无埋点圈选-circler | 基于无埋点的圈选插件，默认集成在无埋点SDK中 | `Circler` | `WebService` |`com.growingio.android:circler:<AndroidSDKVersion />` |
+| 数据调试-debugger | 数据调试Mobile Debugger，默认集成在埋点SDK中 | `Debugger` | `WebService` | `com.growingio.android:debugger:<AndroidSDKVersion />` |
+| 混合开发数据收集-hybrid | 混合开发模式，默认集成在埋点SDK中，需要手动注入（无埋点中自动注入） | 1. `HybridBridge` <br /> 2. `HybridDom` | 1. `Boolean` <br /> 2.`HybridJson` | `com.growingio.android:hybird:<AndroidSDKVersion />` |
+| 数据库-database | event数据库为sqplite，默认集成在埋点SDK中 | `EventDatabase` | `EventDbResult` | `com.growingio.android:database:<AndroidSDKVersion />` |
+| 数据传输格式-json | 使用json格式保存和上传事件数据，sdk 默认 | `EventFormatData` | `EventByteArray` | `com.growingio.android:json:<AndroidSDKVersion />` |
+| 数据传输格式-protobuf | 使用protobuf格式保存和上传事件数据，需要集成生效 | `EventFormatData` | `EventByteArray` | `com.growingio.android:protobuf:<AndroidSDKVersion />` |
 | 更多开发中... |
 
 
@@ -31,10 +31,10 @@ SDK 可以通过集成不同的模块实现功能的自定义，在 GrowingIO �
 
 | 名称     | 说明 | 依赖 |
 | :------- | :------:  | :---|
-| 埋点 Library | 埋点核心库，包含最基本的埋点逻辑 |  `com.growingio.android:tracker-core:3.3.5` |
-| 无埋点 Library | 无埋点核心库，依赖于埋点核心库，包含无埋点的注入逻辑 |  `com.growingio.android:autotracker-core:3.3.5` |
-| 模块注解库 | 注解声明，通过注解可以自动生成 SDK 的初始化类来注册所有的模块和聚合模块内的配置类。| `com.growingio.android:annotation:3.3.5` |
-| 注解解析器 | 与上面注解配合使用 | `com.growingio.android:compiler:3.3.5` |
+| 埋点 Library | 埋点核心库，包含最基本的埋点逻辑 |  `com.growingio.android:tracker-core:<AndroidSDKVersion />` |
+| 无埋点 Library | 无埋点核心库，依赖于埋点核心库，包含无埋点的注入逻辑 |  `com.growingio.android:autotracker-core:<AndroidSDKVersion />` |
+| 模块注解库 | 注解声明，通过注解可以自动生成 SDK 的初始化类来注册所有的模块和聚合模块内的配置类。| `com.growingio.android:annotation:<AndroidSDKVersion />` |
+| 注解解析器 | 与上面注解配合使用 | `com.growingio.android:compiler:<AndroidSDKVersion />` |
 
 具体版本请到 [新功能介绍](/docs) 查阅
 
@@ -54,7 +54,7 @@ buildscript {
     }
     dependencies {
         //无埋点注入插件
-        classpath "com.growingio.android:autotracker-gradle-plugin:3.3.5"
+        classpath "com.growingio.android:autotracker-gradle-plugin:<AndroidSDKVersion />"
     }
 }
 ```
@@ -71,7 +71,7 @@ plugins {
 
 dependencies {
 	//无埋点基础库
-	implementation 'com.growingio.android:autotracker-core:3.3.5'
+	implementation 'com.growingio.android:autotracker-core:<AndroidSDKVersion />'
 }
 
 ```
@@ -83,11 +83,11 @@ dependencies {
 ```groovy
 dependencies {
 	//无埋点基础库
-	implementation 'com.growingio.android:autotracker-core:3.3.5'
+	implementation 'com.growingio.android:autotracker-core:<AndroidSDKVersion />'
 
 	//所需的模块
-	implementation 'com.growingio.android:okhttp3:3.3.5'
-	implementation 'com.growingio.android:json:3.3.5'
+	implementation 'com.growingio.android:okhttp3:<AndroidSDKVersion />'
+	implementation 'com.growingio.android:json:<AndroidSDKVersion />'
 }
 ```
 
@@ -98,22 +98,22 @@ dependencies {
 ```groovy
 dependencies {
 	//无埋点基础库
-	implementation 'com.growingio.android:autotracker-core:3.3.5'
+	implementation 'com.growingio.android:autotracker-core:<AndroidSDKVersion />'
 
 	//所需的模块
-	implementation 'com.growingio.android:okhttp3:3.3.5'
-	implementation 'com.growingio.android:json:3.3.5'
+	implementation 'com.growingio.android:okhttp3:<AndroidSDKVersion />'
+	implementation 'com.growingio.android:json:<AndroidSDKVersion />'
 
 	//注解解析
-	implementation 'com.growingio.android:annotation:3.3.5'
-	annotationProcessor 'com.growingio.android:compiler:3.3.5'
+	implementation 'com.growingio.android:annotation:<AndroidSDKVersion />'
+	annotationProcessor 'com.growingio.android:compiler:<AndroidSDKVersion />'
 }
 ```
 
 :::tip kapt
 若使用kotlin，可以通过 kapt 来依赖注解器
 
-`kapt 'com.growingio.android:compiler:3.3.5'`
+`kapt 'com.growingio.android:compiler:<AndroidSDKVersion />'`
 :::
 
 ### 4. 使用注解自定义SDK的属性

--- a/docs/android/develop/custom module.md
+++ b/docs/android/develop/custom module.md
@@ -28,11 +28,11 @@ title: 自定义模块
 ```groovy
 dependencies {
 	//无埋点基础库
-	implementation 'com.growingio.android:autotracker-core:3.3.5'
+	implementation 'com.growingio.android:autotracker-core:<AndroidSDKVersion />'
 
 	//注解解析
-	implementation 'com.growingio.android:annotation:3.3.5'
-	annotationProcessor 'com.growingio.android:compiler:3.3.5'
+	implementation 'com.growingio.android:annotation:<AndroidSDKVersion />'
+	annotationProcessor 'com.growingio.android:compiler:<AndroidSDKVersion />'
 }
 ```
 

--- a/docs/giokit/android/integrate.md
+++ b/docs/giokit/android/integrate.md
@@ -26,7 +26,7 @@ buildscript {
     }
     dependencies {
         // GioKit plugin
-        classpath "com.growingio.giokit:giokit-plugin:1.1.0"
+        classpath "com.growingio.giokit:giokit-plugin:<GioKitAndroidSDKVersion />"
     }
 }
 
@@ -62,8 +62,8 @@ apply plugin: 'com.growingio.giokit.saas'
 dependencies {
     ...
     // GioKit
-    debugImplementation "com.growingio.giokit:giokit:1.1.0"
-    releaseImplementation "com.growingio.giokit:giokit-no-op:1.1.0"
+    debugImplementation "com.growingio.giokit:giokit:<GioKitAndroidSDKVersion />"
+    releaseImplementation "com.growingio.giokit:giokit-no-op:<GioKitAndroidSDKVersion />"
 }
 ```
 

--- a/docs/ios/base/index.md
+++ b/docs/ios/base/index.md
@@ -214,7 +214,7 @@ func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
 
 ### 查看集成效果
 运行应用，若日志中输出了  
-`Thank you very much for using GrowingIO. We will do our best to provide you with the best service. GrowingIO version: 3.3.4`  
+`Thank you very much for using GrowingIO. We will do our best to provide you with the best service. GrowingIO version: <iOSSDKVersion />`  
 则说明 SDK 已经集成成功。
 
 若在初始化中 `debugEnabled` 设置为 YES，打开了 Debug，则可以在日志中看到每个事件的 log 日志输出。
@@ -416,7 +416,7 @@ func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
 
 ### 查看集成效果
 运行应用，若日志中输出了  
-`Thank you very much for using GrowingIO. We will do our best to provide you with the best service. GrowingIO version: 3.3.4`  
+`Thank you very much for using GrowingIO. We will do our best to provide you with the best service. GrowingIO version: <iOSSDKVersion />`  
 则说明 SDK 已经集成成功。
 
 若在初始化中 `debugEnabled` 设置为 YES，打开了 Debug ，则可以在日志中看到每个事件的 log 日志输出。
@@ -535,7 +535,7 @@ Swift 项目如需使用 Cocoapods 集成 SDK 3.3.5 版本及以上，会出现 
   #import "GrowingTrackConfiguration+CdpTracker.h"
   ```
 
-  同理，如集成 `pod 'GrowingAnalytics-cdp/Tracker', '3.3.5-beta'`，也需对 Pods/GrowingAnalytics-cdp/Tracker/GrowingTracker.h 进行如上调整
+  同理，如集成 `pod 'GrowingAnalytics-cdp/Tracker'`，也需对 Pods/GrowingAnalytics-cdp/Tracker/GrowingTracker.h 进行如上调整
 
 - 修改 OTHER_SWIFT_FLAGS
 

--- a/github_version_fetch.py
+++ b/github_version_fetch.py
@@ -48,18 +48,6 @@ def github_release(platform):
         pass
     return newest_tag
 
-
-android_replace_pattern = r'(com\.growingio\.android:[\w-]+:)([\d\.]+)'
-giokit_android_replace_pattern = r'(com\.growingio\.giokit:[\w-]+:)([\d\.]+)'
-
-
-class GithubVersionSub(object):
-    def __init__(self, version):
-        self.version = version
-
-    def sub_replace(self, matched):
-        return matched.group(1) + self.version
-
 def hotfix_version(tag):
     if tag is not None \
             and tag != "" \
@@ -68,40 +56,6 @@ def hotfix_version(tag):
             and "HOTFIX" not in tag.upper():
         return False
     return True
-
-def replace_android_version(dir, version):
-    for root, dirs, files in os.walk(dir, followlinks=False):
-        for file in files:
-            md = os.path.join(root, file)
-            if md.lower().endswith(".md"):
-                with(open(md, "r")) as f:
-                    text = f.read()
-                    result = re.sub(android_replace_pattern, GithubVersionSub(version).sub_replace, text)
-                    f.close()
-                with(open(md, "w")) as f:
-                    f.write(result)
-                    f.close()
-                    print("update file:<" + md + "> to newest version:" + version)
-                    pass
-    pass
-
-
-def replace_giokit_android_version(dir, version):
-    for root, dirs, files in os.walk(dir, followlinks=False):
-        for file in files:
-            md = os.path.join(root, file)
-            if md.lower().endswith(".md"):
-                with(open(md, "r")) as f:
-                    text = f.read()
-                    result = re.sub(giokit_android_replace_pattern, GithubVersionSub(version).sub_replace, text)
-                    f.close()
-                with(open(md, "w")) as f:
-                    f.write(result)
-                    f.close()
-                    print("update file:<" + md + "> to newest version:" + version)
-                    pass
-    pass
-
 
 version_pattern = r'\d+\.(?:\d+\.)*\d+'
 
@@ -115,17 +69,7 @@ if __name__ == '__main__':
             continue
         platform_newest_tag = github_release(platform)
         if not hotfix_version(platform_newest_tag):
-            version = re.findall(version_pattern, platform_newest_tag)[0]
-            name = platform['name']
-
-            # update android version
-            if "android" == name.lower():
-                replace_android_version(platform["distPath"], version)
-            # update giokit android version
-            if "giokit android" == name.lower():
-                replace_giokit_android_version(platform["distPath"], version)
-
-            platform['version'] = version
+            platform['version'] = re.findall(version_pattern, platform_newest_tag)[0]
 
     with(open(config_file, 'w')) as f:
         json.dump(config, f, ensure_ascii=False, indent=2)

--- a/replace_latest_version_in_md.py
+++ b/replace_latest_version_in_md.py
@@ -1,0 +1,32 @@
+import json
+import os
+
+def replace_latest_version_in_md(platform):
+    for root, dirs, files in os.walk(platform["distPath"], followlinks=False):
+        for file in files:
+            md = os.path.join(root, file)
+            if md.lower().endswith(".md"):
+                with(open(md, "r")) as f:
+                    text = f.read()
+                    text = text.replace(platform['replace'], platform['version'])
+                    f.close()
+                with(open(md, "w")) as f:
+                    f.write(text)
+                    f.close()
+                    print("update file:<" + md + "> to newest version:" + platform['version'])
+                    pass
+    pass
+
+if __name__ == '__main__':
+    config_file = './version_config.json'
+    with(open(config_file, 'r')) as f:
+        config = json.load(f)
+        for platform in config:
+            if platform['enable'] is False:
+                print("platform is disable, skip platform " + platform['name'])
+                continue
+            if not platform['replace']:
+                print("platform have not replaceable text, skip platform " + platform['name'])
+                continue
+            replace_latest_version_in_md(platform)
+        f.close()

--- a/version_config.json
+++ b/version_config.json
@@ -5,7 +5,8 @@
     "releaseUrl": "https://api.github.com/repos/growingio/growingio-sdk-android-autotracker/releases",
     "distPath": "docs/android/",
     "fileName": "version.md",
-    "enable": true
+    "enable": true,
+    "replace": "<AndroidSDKVersion />"
   },
   {
     "name": "iOS",
@@ -13,7 +14,8 @@
     "releaseUrl": "https://api.github.com/repos/growingio/growingio-sdk-ios-autotracker/releases",
     "distPath": "docs/ios/",
     "fileName": "version.md",
-    "enable": true
+    "enable": true,
+    "replace": "<iOSSDKVersion />"
   },
   {
     "name": "webjs",
@@ -21,7 +23,8 @@
     "releaseUrl": "",
     "distPath": "docs/webjs/",
     "fileName": "version.md",
-    "enable": false
+    "enable": false,
+    "replace": ""
   },
   {
     "name": "GioKit Android",
@@ -29,7 +32,8 @@
     "releaseUrl": "https://api.github.com/repos/growingio/giokit-android/releases",
     "distPath": "docs/giokit/android/",
     "fileName": "version.md",
-    "enable": true
+    "enable": true,
+    "replace": "<GioKitAndroidSDKVersion />"
   },
   {
     "name": "GioKit iOS",
@@ -37,6 +41,7 @@
     "releaseUrl": "https://api.github.com/repos/growingio/growingio-sdk-ios-toolskit/releases",
     "distPath": "docs/giokit/ios/",
     "fileName": "version.md",
-    "enable": false
+    "enable": true,
+    "replace": "<GioKitiOSSDKVersion />"
   }
 ]


### PR DESCRIPTION
## PR 内容

feat: 在 docusaurus deploy 前进行 latest version 纯文本替换

优点：相对于原先 github_version_fetch.py 中的正则替换，适配了不符合正则中的包名规则但出现 version 的情况：
`!!! Thank you very much for using GrowingIO. We will do our best to provide you with the best service. !!!`  
`!!! GrowingIO Tracker version: 3.3.4 !!!`  
缺点：本地进行 docusaurus start，界面上对应的 version 没有替换

## 测试步骤

1. 本地执行
```
python github_version_fetch.py
```
查看 version_config.json，是否为最新版本，对应的 `docs/**/version.md` 是否有最新版本记录；

2. 本地执行
```
python replace_latest_version_in_md.py
```
查看 `docs/**/*.md` 中的 `<XXSDKVersion />` 是否替换为最新版本

## 影响范围

CI/CD

## 是否属于重要变动？

- [ ] 是
- [x] 否

## 其他信息

以下 2 种方式也可以实现动态替换 version:
1. docusaurus.config.js [配置环境变量 customFields](https://docusaurus.io/zh-CN/docs/next/deployment#using-environment-variables) + React Components
2. MDX 2.0 https://github.com/facebook/docusaurus/issues/4029 + [docusaurus-mdx-2](https://github.com/pomber/docusaurus-mdx-2)

但无论是 React Components 还是 MDX 2.0 都不支持在 Markdown Code/Code Blocks 中使用