### PR TITLE
style: image auto-format

### DIFF
--- a/.github/workflows/image_format.yml
+++ b/.github/workflows/image_format.yml
@@ -1,0 +1,69 @@
+name: Image Format
+
+on:
+  pull_request:
+    paths:
+      - 'static/**'
+
+permissions:
+  contents: write
+
+jobs:
+  image-format:
+    name: Image Format
+    runs-on: macos-latest
+    if: ${{ github.actor != 'GIOSDK' }} # 禁止套娃
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: ./growingio-sdk-docs
+          token: ${{ secrets.GIOSDK_PAT }}
+
+      - name: Get Current Commit ID
+        id: get_commit_id
+        run: |
+          cd ./growingio-sdk-docs
+          CURRENT_COMMIT=$(git rev-parse HEAD)
+          echo "current commit = $CURRENT_COMMIT"
+          echo "commit_id=$CURRENT_COMMIT" >>$GITHUB_OUTPUT
+
+      - name: Checkout avif-cli
+        uses: actions/checkout@v3
+        with:
+          repository: growingio/avif-cli
+          path: ./avif-cli
+
+      - name: Node Version
+        run: node -v
+
+      - name: Image Format
+        run: |
+          cd ./avif-cli
+          npm install
+          npx webp --input="../growingio-sdk-docs/static/**/*.{jpg,jpeg,png}" --verbose || true
+          npx avif --input="../growingio-sdk-docs/static/**/*.{jpg,jpeg,png}" --verbose || true
+
+      - name: Commit
+        run: |
+          cd ./growingio-sdk-docs
+          if [[ $(git status) == *"nothing to commit"* ]]; then
+              echo "All Images formatted correctly."
+          else
+              COMMIT_ID=${{ steps.get_commit_id.outputs.commit_id }}
+              git fetch
+              git checkout ${{ github.head_ref }}
+              CURRENT_COMMIT=$(git rev-parse HEAD)
+              echo "current commit = $CURRENT_COMMIT"
+              if [[ $COMMIT_ID != $CURRENT_COMMIT ]]; then
+                  echo "Skipping commit as there are new pushes."
+                  exit 0
+              fi
+
+              git config user.name GIOSDK
+              git config user.email sdk-integration@growingio.com
+              git add .
+              git commit -m "style: image format"
+              git push origin ${{ github.head_ref }}
+          fi


### PR DESCRIPTION
## PR 内容

提交 PR 时，如果对 `static/` 目录有更改，即对图片资源更改，则会自动转格式到 webp 和 avif 并使用 GIOSDK 账号进行 git push，适配 #238

在 .md 中仅需按照 ImageLoader 的正确使用方式使用即可
```markdown
<ImageLoader path="img/imagename" />
<ImageLoader path="img/imagename" width="50%" height="50%" />
```

* 如果该 PR 对 `static/` 目录有更改，不论后续的 commit 是否有改动过该目录，每次 commit 都会执行此 workflow
* 多次 commit，除最后一次 commit 外，所触发的 workflow 都会跳过
* 如果图片资源的文件名未改动，仅改变二进制内容，则会认为无需转格式，这种场景无法触发自动转格式，请务必**对新文件重命名**
* 无用的旧图片的删除功能待完善 (TODO)