### PR TITLE
 fix: Temporarily take down Flutter

### DIFF
--- a/docs/framework/flutter/Flutter SDK.md
+++ b/docs/framework/flutter/Flutter SDK.md
@@ -25,34 +25,12 @@ import TabItem from '@theme/TabItem';
 
 以工程`flutter_app`为例，在`pubspec.yaml`文件中添加依赖。
 
-<Tabs
-  groupId="sdk-type"
-  defaultValue="autotracker"
-  values={[
-    {label: '无埋点', value: 'autotracker'},
-    {label: '埋点', value: 'tracker'},
-  ]
-}>
-
-<TabItem value="autotracker">
 
 ```c
 dependencies:
-  growingio_autotracker_flutter_plugin: '4.0.0'
+  growingio_flutter_plugin: '4.0.0'
 ```
 
-</TabItem>
-
-<TabItem value="tracker">
-
-```c
-dependencies:
-  growingio_tracker_flutter_plugin: '4.0.0'
-```
-
-</TabItem>
-
-</Tabs>
 
 然后执行 `flutter pub get` 指令安装插件。
 

--- a/docs/framework/flutter/Flutter SDK.md
+++ b/docs/framework/flutter/Flutter SDK.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: Flutter SDK 插件
 ---
 
-Flutter SDK 插件虽然提供了 无埋点SDK 和 埋点SDK 两个版本，但是在使用 Flutter 无埋点SDK前需要按照 [Flutter Aspect 集成](/docs/framework/flutter/Flutter%20Aspect) 才能使无埋点功能生效。
+Flutter SDK 插件同时具备 无埋点SDK 和 埋点SDK 功能，但是在使用 Flutter 无埋点功能前需要按照 [Flutter Aspect 集成](/docs/framework/flutter/Flutter%20Aspect) 才能使无埋点功能生效。
 
 ---
 
@@ -38,7 +38,7 @@ import TabItem from '@theme/TabItem';
 
 ```c
 dependencies:
-  growingio_autotracker_flutter_plugin: '2.0.1'
+  growingio_autotracker_flutter_plugin: '4.0.0'
 ```
 
 </TabItem>
@@ -47,7 +47,7 @@ dependencies:
 
 ```c
 dependencies:
-  growingio_tracker_flutter_plugin: '2.0.1'
+  growingio_tracker_flutter_plugin: '4.0.0'
 ```
 
 </TabItem>

--- a/docs/framework/flutter/index.md
+++ b/docs/framework/flutter/index.md
@@ -3,16 +3,10 @@ slug: /framework/flutter
 title: Flutter SDK
 ---
 
-Flutter SDK 提供了 [无埋点SDK](/docs/framework/flutter/index.md) 和 [埋点SDK](/docs/framework/flutter/index.md) 两个版本：
-* 埋点SDK 只自动采集用户访问事件，需要开发人员调用相应埋点 API 采集埋点事件;
-* 无埋点SDK 具备 埋点SDK 的所有功能，同时具备自动采集基本用户行为事件，如页面访问，点击事件等。
+Flutter SDK 提供了插件集成，将与原生SDK一起将 Flutter 事件发送至数据端。 
 
 ## 版本记录
-|    版本    | 说明 |  日期  |
-|:-------:| :----  |  :-------:  |
-| v2.1.0 | 适配Android 版本 4.2.0<br/>支持 Fluter 全页面自动采集 | 2024-03-29 |
-| v2.0.1 | 稳定性优化，包括：<br/>- 在导航返回时补发 page<br/>- 重命名 advertModule/advertConfig 为 adsModule/adsConfig<br/>- 添加 analytics adapter 模块<br/>- 升级 iOS SDK 版本为 4.2.0 | 2024-03-19 |
-| v2.0.0 | 新版本 与 GrowingIO SDK 4.0 同步，添加新的接口和参数<br/>- Flutter 的 Page 不再基于 Router，由 mixin 类实现，更加清晰的生命周期逻辑和代码结构；<br/>- 圈选的元素只有在定义为 Page 的页面下才能发送元素；<br/>- 无埋点点击事件现在异步发送。 | 2024-01-25 |
+将会与SDK 4.3.0 一起发布。
 
 :::info
 **Dart SDK**： >=2.16.0 


### PR DESCRIPTION
由于版本冲突，计划将 4.0.0  Flutter 插件更改名称与原生SDK 4.3.0 一同发布。