### PR TITLE
feat: add an FAQ

### DIFF
--- a/docs/question/android.md
+++ b/docs/question/android.md
@@ -92,3 +92,13 @@ classpath("com.growingio.android:autotracker-gradle-plugin:3.3.5") {
 
 ### 12. SDK如何支持合规和第三方安全检测，以及GDPR（欧盟《一般数据保护条例》）？
 **A：** 参考[Android SDK合规说明](/knowledge/compliance/androidCompliance)
+
+### 13. SDK集成无埋点/[H5混合模块](/docs/android/modules/hybrid%20module)后，发现WebView数据打通未生效？
+**A：**
+检查项目中是否有依赖听云SDK插件/火山SDK插件
+```groovy
+// 请保证无埋点相关插件在听云SDK插件/火山SDK插件前面
+apply plugin: 'com.growingio.android.autotracker'
+apply plugin: 'com.bytedance.std.tracker'
+apply plugin: 'newlens'
+```


### PR DESCRIPTION
增加Android常见问题
火山引擎SDK的WebView.loadUrl字节码处理方式是替换用户调用，内部通过反射调用，导致我们后注入找不到注入点
听云SDK的WebView.loadUrl字节码处理方式是将用户调用放到不执行的代码块中，导致我们后注入后不生效，考虑到听云早期版本注入方式，SDK会自动过滤听云包名，导致无有效注入点
建议用户调整注入顺序